### PR TITLE
rootfs: fixes missing dbclient issue.

### DIFF
--- a/yarvt
+++ b/yarvt
@@ -323,6 +323,9 @@ function build_dropbear () {
 	ln -s dropbearmulti dropbear
 	ln -s dropbearmulti ssh
 	ln -s dropbearmulti scp
+	mkdir -p ${INSTALL_DIR}/usr/bin
+	cd ${INSTALL_DIR}/usr/bin
+	ln -s /bin/dropbearmulti dbclient
 
 	cd ${SAVED_PWD}
 }


### PR DESCRIPTION
This should fix the issue with scp (and other utilities I suppose) failing due to dbclient not being at the expected location.